### PR TITLE
Fix `flamegraph.start_profiler`

### DIFF
--- a/flamegraph/flamegraph.py
+++ b/flamegraph/flamegraph.py
@@ -17,7 +17,7 @@ def get_thread_name(ident):
     return str(ident) # couldn't find, return something useful anyways
 
 _default_format = '%(fun)s@%(short_fname)s:%(line)s'
-def default_format_entry(fi, fmt):
+def default_format_entry(fi, fmt=_default_format):
     return fmt % fi._asdict()
 
 FrameInfo = collections.namedtuple('FrameInfo', ['fname', 'short_fname', 'line', 'fun'])


### PR DESCRIPTION
`default_format_entry` expects to be given the format string as a positional argument where as `start_profiler` expected that `default_format_entry` would take a single argument.